### PR TITLE
Add CODEOWNERS file for vault-scanning team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hashicorp/vault-scanning


### PR DESCRIPTION
Adding CODEOWNERS to point to the vault scanning team